### PR TITLE
Fix that prevents multiple listener calls when EXPANDED or COLLAPSED

### DIFF
--- a/core/src/main/java/com/psoffritti/slidingpanel/SlidingPanel.kt
+++ b/core/src/main/java/com/psoffritti/slidingpanel/SlidingPanel.kt
@@ -57,6 +57,8 @@ class SlidingPanel(context: Context, attrs: AttributeSet? = null) : FrameLayout(
     var state = PanelState.COLLAPSED
         private set
 
+    private var previousState: PanelState ?= null
+
     // A value between 1.0 and 0.0 (0.0 = COLLAPSED, 1.0 = EXPANDED)
     private var currentSlide = 0.0f
 
@@ -379,7 +381,10 @@ class SlidingPanel(context: Context, attrs: AttributeSet? = null) : FrameLayout(
             slidingView.x = currentSlideNonNormalized
 
         invalidate()
-        notifyListeners(currentSlide)
+        if (state != previousState || state == PanelState.SLIDING) {
+            notifyListeners(currentSlide)
+            previousState = state
+        }
     }
 
     /**


### PR DESCRIPTION
Hi! Thanks for the lib. Cool that it's written in Kotlin!

I found it's not correct that listener triggers with Expanded/Collapsed state while it's already Expanded/Collapsed;

Tried to not use `CMD + OPT + L` to make PR keep small