### PR TITLE
Fix sliding freezes when touch outside

### DIFF
--- a/core/src/main/java/com/psoffritti/slidingpanel/SlidingPanel.kt
+++ b/core/src/main/java/com/psoffritti/slidingpanel/SlidingPanel.kt
@@ -57,6 +57,8 @@ class SlidingPanel(context: Context, attrs: AttributeSet? = null) : FrameLayout(
     var state = PanelState.COLLAPSED
         private set
 
+    private var previousState: PanelState ?= null
+
     // A value between 1.0 and 0.0 (0.0 = COLLAPSED, 1.0 = EXPANDED)
     private var currentSlide = 0.0f
 
@@ -379,7 +381,10 @@ class SlidingPanel(context: Context, attrs: AttributeSet? = null) : FrameLayout(
             slidingView.x = currentSlideNonNormalized
 
         invalidate()
-        notifyListeners(currentSlide)
+        if (state != previousState || state == PanelState.SLIDING) {
+            notifyListeners(currentSlide)
+            previousState = state
+        }
     }
 
     /**


### PR DESCRIPTION
The idea is to complete sliding and stop consuming new touch events when touch goes outside of sliding area. It usually happens when DragView is small, so that the sliding view "freezes"